### PR TITLE
Fix bower package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,9 @@
 {
   "name": "Colors.js",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "homepage": "http://matthewbjordan.me/Colors/",
   "description": "An easy to use color manipulation library that is lightweight and very functional.",
-  "main": "colors.min.js",
+  "main": "./colors.js",
   "keywords": [
     "colors",
     "color"

--- a/colors.js
+++ b/colors.js
@@ -1,5 +1,5 @@
 /**
- * @license Colors JS Library v1.2.3
+ * @license Colors JS Library v1.2.4
  * Copyright 2012-2013 Matt Jordan
  * Licensed under Creative Commons Attribution-ShareAlike 3.0 Unported. (http://creativecommons.org/licenses/by-sa/3.0/)
  * https://github.com/mbjordan/Colors

--- a/colors.min.js
+++ b/colors.min.js
@@ -1,5 +1,5 @@
 /*
- Colors JS Library v1.2.3
+ Colors JS Library v1.2.4
  Copyright 2012-2013 Matt Jordan
  Licensed under Creative Commons Attribution-ShareAlike 3.0 Unported. (http://creativecommons.org/licenses/by-sa/3.0/)
  https://github.com/mbjordan/Colors


### PR DESCRIPTION
Bower package reference to `main` needs to be a directory path (like package.json). It should also be the un-minified version by default.

For example running `bower info Colors.js` reveals no `main`, and through the programmatic API:

``` js
bower.commands.list().on('end', function(packages) {
  for (var packageName in packages) {
    console.log(packages[packageName].pkgMeta.main);
    // Others yield './somefiles.js' but this one is `undefined`
  }
});
```
